### PR TITLE
test(plugins): use custom `babelrc` to instrument unit tests

### DIFF
--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -66,5 +66,6 @@ export default function plugins(
       return null;
     },
   });
+  on('file:preprocessor', require('@cypress/code-coverage/use-babelrc'));
   return { ...config, env: { ...config.env, ...env } };
 }


### PR DESCRIPTION
Blocked by cypress-io/cypress#19530 and cypress-io/code-coverage#518.